### PR TITLE
Add oracle client certificate

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -18,14 +18,8 @@ unzip instantclient-sdk-linux.x64-21.8.0.0.0dbru.zip && rm instantclient-sdk-lin
 mv instantclient{_21_8,}
 cd instantclient
 
-echo "-----> Oracle Client Installed"
-
-echo "-----> Oracle Client Certificate"
-
-unzip $BUILD_DIR/pki.zip -d $CLIENT_BUILD_DIR/pki
-ln -s $CLIENT_BUILD_DIR/pki /etc/pki
-
-echo "-----> Oracle Client Certificate: installed"
+echo "-----> Creating sqlnet.ora config"
+echo "SSL_CLIENT_AUTHENTICATION=false" > ./network/admin/sqlnet.ora
 
 cat <<EOT > $BP_DIR/export
 export LD_LIBRARY_PATH=$CLIENT_BUILD_DIR/instantclient/:$BUILD_DIR/.apt/lib/x86_64-linux-gnu/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
@@ -41,4 +35,3 @@ fi
 
 cp $BP_DIR/profile/* $BUILD_DIR/.profile.d/
 
-echo "-----> Oracle Client Installed"


### PR DESCRIPTION
Add the `oracle` tls certificate so the client can connect to oracle cloud hosted instance of autonomous database over TLS successfully.